### PR TITLE
fix: disables i18nex/no-literal-string rule for stories

### DIFF
--- a/packages/eslint-utils/src/eslint.config.js
+++ b/packages/eslint-utils/src/eslint.config.js
@@ -116,7 +116,7 @@ export const config = eslintTs.config(
         }
     },
     {
-        files: ["*.spec.ts", "*.spec.tsx", "*.spec.js", "*.spec.jsx"],
+        files: ["*.spec.ts", "*.spec.tsx", "*.spec.js", "*.spec.jsx", "*.story.tsx"],
 
         rules: {
             "i18next/no-literal-string": 0


### PR DESCRIPTION
# Description

Disables i18next/no-literal-string for stories

Fixes #12

# How Has This Been Tested?

N/A

# Checklist:

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
-   [x] Any dependent changes have been merged and published in downstream modules