### PR TITLE
fix: disables i18nex/no-literal-string rule for stories

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -48,3 +48,28 @@ jobs:
                   cache: "npm"
             - uses: ./.github/actions/install
             - uses: ./.github/actions/build
+
+    assign-labels:
+        runs-on: ubuntu-latest
+
+        if: github.event.pull_request.merged == false
+
+        steps:
+            - uses: actions/checkout@v4
+
+            - uses: mauroalderete/action-assign-labels@v1
+              with:
+                github-token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+                pull-request-number: ${{ github.event.pull_request.number }}
+                conventional-commits: |
+                  conventional-commits:
+                    - type: 'fix'
+                      nouns: ['FIX', 'Fix', 'fix', 'FIXED', 'Fixed', 'fixed']
+                      labels: ['bug']
+                    - type: 'feature'
+                      nouns: ['FEATURE', 'Feature', 'feature', 'FEAT', 'Feat', 'feat']
+                      labels: ['enhancement']
+                    - type: 'breaking_change'
+                      nouns: ['BREAKING CHANGE', 'BREAKING', 'MAJOR']
+                      labels: ['breaking-change']
+

--- a/packages/eslint-utils/src/eslint.config.js
+++ b/packages/eslint-utils/src/eslint.config.js
@@ -116,8 +116,7 @@ export const config = eslintTs.config(
         }
     },
     {
-        files: ["*.spec.ts", "*.spec.tsx", "*.spec.js", "*.spec.jsx", "*.story.tsx"],
-
+        files: ["**/*.spec.ts", "**/*.spec.tsx", "**/*.spec.js", "**/*.spec.jsx", "**/*.story.tsx"],
         rules: {
             "i18next/no-literal-string": 0
         }
@@ -132,7 +131,7 @@ export const config = eslintTs.config(
         }
     },
     {
-        files: ["package.json", "package-lock.json"],
+        files: ["**/package.json", "**/package-lock.json"],
         rules: {
             "jsonc/sort-keys": "off"
         }


### PR DESCRIPTION
# Description

Fixes disabling rules for some for specs and stories.

# Checklist:

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
-   [x] Any dependent changes have been merged and published in downstream modules