### PR TITLE
fix: fixes typescript configuration

### DIFF
--- a/packages/eslint-utils/src/eslint.config.js
+++ b/packages/eslint-utils/src/eslint.config.js
@@ -70,10 +70,8 @@ export const config = eslintTs.config(
         },
         settings: {
             "import/resolver": {
-                typescript: {
-                    alwaysTryTypes: true,
-                    project
-                }
+                typescript: true,
+                node: true
             }
         },
         plugins: {


### PR DESCRIPTION
# Description

The import plugin was misconfigured.
`tsConfigRootDir` was set to undefined which led to incorrect behaviour.

# How Has This Been Tested?

Tested on a private project.

# Checklist:

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
-   [x] Any dependent changes have been merged and published in downstream modules